### PR TITLE
img src with HTTPS to fixed mixed content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ xhr.onload = function(){
   $list.innerHTML = data.map(function(d){
     var repo = d.repo;
     if (!repo) return '<li class="unavailable">'
-      + '<img src="http://assets.pokemon.com/assets/cms2/img/pokedex/detail/' + d.id + '.png" width="100" height="100" alt="">'
+      + '<img src="https://assets.pokemon.com/assets/cms2/img/pokedex/detail/' + d.id + '.png" width="100" height="100" alt="">'
       + '<h2>' + d.name + '</h2>'
     + '</li>';
     var longDesc = repo.desc || '';
@@ -103,7 +103,7 @@ xhr.onload = function(){
     var desc = veryLongDesc ? longDesc.slice(0, descLimit-1) + '&hellip;' : longDesc;
     return '<li class="available">'
         + '<a href="https://github.com/' + repo.full_name + '" title="' + (veryLongDesc ? longDesc : '') + '">'
-        + '<img src="http://assets.pokemon.com/assets/cms2/img/pokedex/detail/' + d.id + '.png" width="100" height="100" alt="">'
+        + '<img src="https://assets.pokemon.com/assets/cms2/img/pokedex/detail/' + d.id + '.png" width="100" height="100" alt="">'
         + '<h2>' + d.name + '</h2>'
         + '<div class="metadata">' + desc + '</div>'
         + '<div class="metadata">⭐️ ' + repo.stars + ' 🍴' + repo.forks + '</div>'


### PR DESCRIPTION
Fix mixed content warnings.

Before

<img width="1435" alt="screenshot 2016-07-15 12 24 04" src="https://cloud.githubusercontent.com/assets/1000669/16863793/0c9e8460-4a89-11e6-8374-0f20c0f33578.png">


After

<img width="577" alt="screenshot 2016-07-15 12 37 34" src="https://cloud.githubusercontent.com/assets/1000669/16863782/ef3d0f86-4a88-11e6-96e9-e75b5f2cc26d.png">
<img width="1418" alt="screenshot 2016-07-15 12 37 25" src="https://cloud.githubusercontent.com/assets/1000669/16863783/ef818256-4a88-11e6-8f90-9e4174663e43.png">
